### PR TITLE
Centralize configuration handling

### DIFF
--- a/mcp/cli.js
+++ b/mcp/cli.js
@@ -65,35 +65,34 @@ async function main() {
 
   ServerUtils.setupTransport(config);
 
-  try {
-    ServerUtils.showStartupBanner(config);
+    try {
+      ServerUtils.showStartupBanner(config);
 
-    // Get configurations
-    const serverConfig = ConfigManager.getServerConfig();
-    const ragConfig = ConfigManager.getRagConfig();
+      // Get consolidated configuration
+      const { server: serverConfig, rag: ragConfig } = ConfigManager.getConfig();
 
-    // Create and setup server
-    const server = MCPServerFactory.createServer(serverConfig);
-    const ragService = new RAGService(ragConfig);
-    const toolRegistry = new RAGToolRegistry(ragService);
-    
-    toolRegistry.registerAllTools(server);
-    
-    if (config.verbose) {
-      ServerUtils.showVerboseInfo(config, ragConfig, server);
-    }
-    
-    // Start server
-    await server.start({
-      transportType: config.transport,
-      port: config.port,
-      host: config.host,
-      endpoint: config.endpoint
-    });
-    
-    ServerUtils.showSuccessMessage(config);
-    
-  } catch (error) {
+      // Create and setup server
+      const server = MCPServerFactory.createServer(serverConfig);
+      const ragService = new RAGService(ragConfig);
+      const toolRegistry = new RAGToolRegistry(ragService);
+
+      toolRegistry.registerAllTools(server);
+
+      if (config.verbose) {
+        ServerUtils.showVerboseInfo(config, ragConfig, server);
+      }
+
+      // Start server
+      await server.start({
+        transportType: config.transport,
+        port: config.port,
+        host: config.host,
+        endpoint: config.endpoint
+      });
+
+      ServerUtils.showSuccessMessage(config);
+
+    } catch (error) {
     console.error('❌ Failed to start server:', error.message);
     if (config.verbose) {
       console.error(error.stack);

--- a/mcp/lib/config.js
+++ b/mcp/lib/config.js
@@ -1,6 +1,29 @@
 /**
  * Configuration management for RAG MCP Server
+ * Provides a single entry point for both server and RAG settings.
  */
+
+// Default configuration values for the entire system
+const DEFAULT_CONFIG = {
+  server: {
+    name: 'RAG Service',
+    version: '1.0.0',
+    description: 'A RAG service with local embeddings and vector search',
+    framework: 'fastmcp'
+  },
+  rag: {
+    host: 'localhost',
+    port: 5432,
+    database: 'rag',
+    user: 'raguser',
+    password: 'ragpassword',
+    modelName: 'Xenova/all-MiniLM-L6-v2',
+    generatorConfig: {
+      maxResponseLength: 2000,
+      includeSourceInfo: true
+    }
+  }
+};
 
 export class ConfigManager {
   /**
@@ -88,32 +111,44 @@ export class ConfigManager {
   }
 
   /**
-   * Get RAG configuration from environment variables
+   * Return consolidated configuration with environment overrides.
+   * Environment variables take precedence over defaults.
    */
-  static getRagConfig() {
-    return {
-      host: process.env.RAG_DB_HOST || 'localhost',
-      port: parseInt(process.env.RAG_DB_PORT) || 5432,
-      database: process.env.RAG_DB_NAME || 'rag',
-      user: process.env.RAG_DB_USER || 'raguser',
-      password: process.env.RAG_DB_PASSWORD || 'ragpassword',
-      modelName: process.env.RAG_MODEL_NAME || 'Xenova/all-MiniLM-L6-v2',
-      generatorConfig: {
-        maxResponseLength: 2000,
-        includeSourceInfo: true
-      }
+  static getConfig() {
+    const server = {
+      ...DEFAULT_CONFIG.server,
+      name: process.env.MCP_SERVER_NAME || DEFAULT_CONFIG.server.name,
+      version: process.env.MCP_SERVER_VERSION || DEFAULT_CONFIG.server.version,
+      description:
+        process.env.MCP_SERVER_DESCRIPTION || DEFAULT_CONFIG.server.description,
+      framework: process.env.MCP_SERVER_FRAMEWORK || DEFAULT_CONFIG.server.framework
     };
+
+    const rag = {
+      ...DEFAULT_CONFIG.rag,
+      host: process.env.RAG_DB_HOST || DEFAULT_CONFIG.rag.host,
+      port: parseInt(process.env.RAG_DB_PORT) || DEFAULT_CONFIG.rag.port,
+      database: process.env.RAG_DB_NAME || DEFAULT_CONFIG.rag.database,
+      user: process.env.RAG_DB_USER || DEFAULT_CONFIG.rag.user,
+      password: process.env.RAG_DB_PASSWORD || DEFAULT_CONFIG.rag.password,
+      modelName: process.env.RAG_MODEL_NAME || DEFAULT_CONFIG.rag.modelName,
+      generatorConfig: { ...DEFAULT_CONFIG.rag.generatorConfig }
+    };
+
+    return { server, rag };
   }
 
   /**
-   * Get server configuration
+   * Convenience helper for obtaining only the server configuration
    */
   static getServerConfig() {
-    return {
-      name: 'RAG Service',
-      version: '1.0.0',
-      description: 'A RAG service with local embeddings and vector search',
-      framework: 'fastmcp'
-    };
+    return this.getConfig().server;
+  }
+
+  /**
+   * Convenience helper for obtaining only the RAG configuration
+   */
+  static getRagConfig() {
+    return this.getConfig().rag;
   }
 }

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -5,27 +5,7 @@
 import { MCPServerFactory } from './lib/mcp-server-factory.js';
 import { RAGService } from './lib/rag-service.js';
 import { RAGToolRegistry } from './lib/rag-tool-registry.js';
-
-// Configuration
-const SERVER_CONFIG = {
-  name: 'RAG Service',
-  version: '1.0.0',
-  description: 'A RAG service with local embeddings and vector search',
-  framework: 'fastmcp' // Currently supports 'fastmcp', extensible for other frameworks
-};
-
-const RAG_CONFIG = {
-  host: 'localhost',
-  port: 5432,
-  database: 'rag',
-  user: 'raguser',
-  password: 'ragpassword',
-  modelName: 'Xenova/all-MiniLM-L6-v2',
-  generatorConfig: {
-    maxResponseLength: 2000,
-    includeSourceInfo: true
-  }
-};
+import { ConfigManager } from './lib/config.js';
 
 /**
  * Main server initialization
@@ -33,12 +13,15 @@ const RAG_CONFIG = {
 async function main() {
   try {
     console.error('🚀 Starting RAG MCP Server...');
-    
+
+    // Load consolidated configuration
+    const { server: serverConfig, rag: ragConfig } = ConfigManager.getConfig();
+
     // Create server instance using factory
-    const server = MCPServerFactory.createServer(SERVER_CONFIG);
-    
+    const server = MCPServerFactory.createServer(serverConfig);
+
     // Initialize RAG service
-    const ragService = new RAGService(RAG_CONFIG);
+    const ragService = new RAGService(ragConfig);
     
     // Register all RAG tools
     const toolRegistry = new RAGToolRegistry(ragService);

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,11 @@ node mcp/cli.js --transport httpStream --port 3000 --verbose
 
 ## ⚙️ Configuration
 
+All default server and RAG settings live in a single entry point:
+[`mcp/lib/config.js`](mcp/lib/config.js). The `ConfigManager` merges these
+defaults with environment variables and CLI arguments so overrides are applied
+consistently across the CLI and server.
+
 Set environment variables to customize the setup:
 
 ```bash


### PR DESCRIPTION
## Summary
- consolidate server and RAG defaults in `ConfigManager`
- load shared configuration in `mcp/server.js` and `mcp/cli.js`
- document the single configuration entry point

## Testing
- `npm test` *(fails: docker: not found, missing cheerio)*

------
https://chatgpt.com/codex/tasks/task_e_68c684cbd53883208105c0f64f2c81bb